### PR TITLE
Compact Common.client_options.

### DIFF
--- a/lib/liam/common.rb
+++ b/lib/liam/common.rb
@@ -12,7 +12,7 @@ module Liam
         endpoint: env_credentials['aws']['sns']['endpoint'],
         region: env_credentials['aws']['region'],
         secret_access_key: env_credentials['aws']['secret_access_key']
-      }
+      }.compact
     end
 
     def env_credentials


### PR DESCRIPTION
The SNS and SQS endpoints are set to nil in production, which causes an Aws::SQS::Client error when trying to initialize a new object.

I just used `compact` to remove nil key/values in the `Common.client_options` to avoid that problem.